### PR TITLE
[Fix] CSRF Protection is safe again and don't need to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,8 @@ In the same way you can re-import your yaml file again by selecting: `Import fro
 ## Configuration
 
 ### Page Import
-To use the Page Importer, the CSRF protection for the PageImportController route must be avoided.
 
-To do this, create a file `config/packages/pimcore_admin.yaml` and add the following content:
-
-```yaml
-pimcore_admin:
-    csrf_protection:
-        excluded_routes:
-            - neusta_pimcore_import_export_page_import
-```
+The import process will create a new page with the given data.
 
 ## Contribution
 

--- a/public/js/importPage.js
+++ b/public/js/importPage.js
@@ -54,6 +54,9 @@ neusta_pimcore_import_export.plugin.page.import = Class.create({
                                             headers: {
                                                 'X-Requested-With': 'XMLHttpRequest' // ✅ important for AJAX-Requests
                                             },
+                                            params: {
+                                                'csrfToken': parent.pimcore.settings["csrfToken"]
+                                            },
                                             success: function (form, action) {
                                                 let response = Ext.decode(action.response.responseText);
                                                 pimcore.helpers.showNotification(t('neusta_pimcore_import_export_import_dialog_notification_success'), response.message, 'success');


### PR DESCRIPTION
We've have found a way to add the current csrfToken to our request and now it works.