### PR TITLE
Error in importing Assets by ZIP file - physical files are missing

### DIFF
--- a/src/Controller/Admin/ImportDataObjectsController.php
+++ b/src/Controller/Admin/ImportDataObjectsController.php
@@ -6,6 +6,7 @@ use Neusta\Pimcore\ImportExportBundle\Controller\Admin\Base\AbstractImportBaseCo
 use Neusta\Pimcore\ImportExportBundle\Import\Importer;
 use Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\DataObjectRepository;
 use Pimcore\Model\DataObject;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,10 +21,11 @@ final class ImportDataObjectsController extends AbstractImportBaseController
      * @param Importer<\ArrayObject<int|string, mixed>, DataObject> $importer
      */
     public function __construct(
+        LoggerInterface $logger,
         DataObjectRepository $repository,
         private Importer $importer,
     ) {
-        parent::__construct($repository, 'DataObject');
+        parent::__construct($logger, $repository, 'DataObject');
     }
 
     #[Route(

--- a/src/Controller/Admin/ImportDocumentsController.php
+++ b/src/Controller/Admin/ImportDocumentsController.php
@@ -6,6 +6,7 @@ use Neusta\Pimcore\ImportExportBundle\Controller\Admin\Base\AbstractImportBaseCo
 use Neusta\Pimcore\ImportExportBundle\Import\Importer;
 use Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\DocumentRepository;
 use Pimcore\Model\Document;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,10 +21,11 @@ final class ImportDocumentsController extends AbstractImportBaseController
      * @param Importer<\ArrayObject<int|string, mixed>, Document> $importer
      */
     public function __construct(
+        LoggerInterface $logger,
         DocumentRepository $repository,
         private Importer $importer,
     ) {
-        parent::__construct($repository, 'Document');
+        parent::__construct($logger, $repository, 'Document');
     }
 
     #[Route(


### PR DESCRIPTION
[NSDTRINITY-90] fix for not uploaded physical files in asset import and clean up temporary unzipped files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cleanup of temporary files after importing assets from ZIP files, reducing leftover files and potential storage issues.

- **Refactor**
	- Enhanced asset import handling for ZIP files to read file contents properly and streamlined cleanup processes to ensure temporary directories are removed after imports.
	- Added logging capability to import controllers for better monitoring and diagnostics.
	- Introduced standardized cleanup calls after import operations to maintain system hygiene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->