### PR TITLE
[FIX] add controller field to converters_populators

### DIFF
--- a/config/pimcore/export/documents/converters_populators.yaml
+++ b/config/pimcore/export/documents/converters_populators.yaml
@@ -19,6 +19,7 @@ neusta_converter:
         published: ~
         path: ~
         parentId: ~
+        controller: ~
 
     neusta_pimcore_import_export.editable_converter:
       target: Neusta\Pimcore\ImportExportBundle\Model\Document\Editable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for a new document property, "controller", in the export configuration. This property is now included by default with a null value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->