### PR TITLE
Export assigned pimcore tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Add
+ - Export and import assigned tags for assets, documents, folders, and data objects.
+
 ## 4.0.0
 
 - update: add Pimcore 12 support and drop support for Pimcore <11.5

--- a/config/pimcore/export/assets/converters_populators.yaml
+++ b/config/pimcore/export/assets/converters_populators.yaml
@@ -10,6 +10,7 @@ neusta_converter:
       target: Neusta\Pimcore\ImportExportBundle\Model\Asset\Asset
       populators:
         - Neusta\Pimcore\ImportExportBundle\Populator\IdsPopulator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         key: ~
         type: ~

--- a/config/pimcore/export/documents/converters_populators.yaml
+++ b/config/pimcore/export/documents/converters_populators.yaml
@@ -11,6 +11,7 @@ neusta_converter:
       populators:
         - Neusta\Pimcore\ImportExportBundle\Populator\IdsPopulator
         - neusta_pimcore_import_export.document.properties.populator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         key: ~
         type: ~
@@ -22,6 +23,7 @@ neusta_converter:
       populators:
         - Neusta\Pimcore\ImportExportBundle\Populator\IdsPopulator
         - neusta_pimcore_import_export.document.properties.populator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         key: ~
         type: ~
@@ -35,6 +37,7 @@ neusta_converter:
         - neusta_pimcore_import_export.snippet.controller.populator
         - neusta_pimcore_import_export.snippet.editables.populator
         - neusta_pimcore_import_export.document.properties.populator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         key: ~
         type: ~
@@ -49,6 +52,7 @@ neusta_converter:
         - neusta_pimcore_import_export.snippet.editables.populator
         - neusta_pimcore_import_export.page.title.populator
         - neusta_pimcore_import_export.document.properties.populator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         key: ~
         type: ~

--- a/config/pimcore/export/elements/converters_populators.yaml
+++ b/config/pimcore/export/elements/converters_populators.yaml
@@ -4,7 +4,7 @@
 neusta_converter:
   converter:
     ###########################################################
-    # Export Converter (Pimcore Asset -> Folder)
+    # Export Converter (Basic Elements)
     ###########################################################
     neusta_pimcore_import_export.export_element:
       target: Neusta\Pimcore\ImportExportBundle\Model\Element
@@ -15,9 +15,28 @@ neusta_converter:
         type: ~
         path: ~
 
+    ###########################################################
+    # Export Converter (\Pimcore\Model\Element\Tag -> Neusta\Pimcore\ImportExportBundle\Model\Tag\Tag)
+    ###########################################################
+    neusta_pimcore_import_export.export_tag:
+      target: Neusta\Pimcore\ImportExportBundle\Model\Tag\Tag
+      populators:
+        - neusta_pimcore_import_export.tag.populator
+      properties:
+        key: name
+
 services:
   _defaults:
     autowire: true
     autoconfigure: true
 
   Neusta\Pimcore\ImportExportBundle\Populator\IdsPopulator: ~
+
+  neusta_pimcore_import_export.tag.populator:
+    class:
+      Neusta\Pimcore\ImportExportBundle\Populator\Tag\TagPopulator
+
+  neusta_pimcore_import_export.assigned_tags.populator:
+    class: Neusta\Pimcore\ImportExportBundle\Populator\AssignedTagsPopulator
+    arguments:
+      $tagConverter: '@neusta_pimcore_import_export.export_tag'

--- a/config/pimcore/export/objects/converters_populators.yaml
+++ b/config/pimcore/export/objects/converters_populators.yaml
@@ -10,6 +10,7 @@ neusta_converter:
       target: Neusta\Pimcore\ImportExportBundle\Model\Object\Folder
       populators:
         - Neusta\Pimcore\ImportExportBundle\Populator\IdsPopulator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         key: ~
         type: ~
@@ -21,6 +22,7 @@ neusta_converter:
         - Neusta\Pimcore\ImportExportBundle\Populator\IdsPopulator
         - neusta_pimcore_import_export.export_object.fields.populator
         - neusta_pimcore_import_export.export_object.relations.populator
+        - neusta_pimcore_import_export.assigned_tags.populator
       properties:
         className: ~
         key: ~

--- a/config/pimcore/import/assets/converters_populators.yaml
+++ b/config/pimcore/import/assets/converters_populators.yaml
@@ -14,6 +14,7 @@ neusta_converter:
         - neusta_pimcore_import_export.assets.import.populator.type
         - neusta_pimcore_import_export.assets.import.populator.path
         - neusta_pimcore_import_export.assets.import.populator.parentId
+        - neusta_pimcore_import_export.import.tags.populator
 
 services:
   _defaults:

--- a/config/pimcore/import/documents/converters_populators.yaml
+++ b/config/pimcore/import/documents/converters_populators.yaml
@@ -15,6 +15,7 @@ neusta_converter:
         - neusta_pimcore_import_export.documents.import.populator.published
         - neusta_pimcore_import_export.documents.import.populator.path
         - neusta_pimcore_import_export.documents.import.populator.parentId
+        - neusta_pimcore_import_export.import.tags.populator
 
     neusta_pimcore_import_export.import_page:
       target: Pimcore\Model\Document\Page
@@ -30,6 +31,7 @@ neusta_converter:
         - Neusta\Pimcore\ImportExportBundle\Populator\Document\EditablesPopulator
         - Neusta\Pimcore\ImportExportBundle\Populator\Document\PropertiesPopulator
         - Neusta\Pimcore\ImportExportBundle\Populator\Document\PageTitlePopulator
+        - neusta_pimcore_import_export.import.tags.populator
 
     neusta_pimcore_import_export.import_snippet:
       target: Pimcore\Model\Document\Snippet
@@ -43,6 +45,7 @@ neusta_converter:
         - neusta_pimcore_import_export.documents.import.populator.parentId
         - Neusta\Pimcore\ImportExportBundle\Populator\Document\EditablesPopulator
         - Neusta\Pimcore\ImportExportBundle\Populator\Document\PropertiesPopulator
+        - neusta_pimcore_import_export.import.tags.populator
 
 services:
   _defaults:

--- a/config/pimcore/import/objects/converters_populators.yaml
+++ b/config/pimcore/import/objects/converters_populators.yaml
@@ -28,6 +28,7 @@ services:
         - '@neusta_pimcore_import_export.dataobject.import.populator.parentId'
         - '@Neusta\Pimcore\ImportExportBundle\Populator\DataObjectImportRelationsPopulator'
         - '@Neusta\Pimcore\ImportExportBundle\Populator\DataObjectImportFieldsPopulator'
+        - '@neusta_pimcore_import_export.import.tags.populator'
 
   neusta_pimcore_import_export.import_object.supports_aware:
     class: Neusta\Pimcore\ImportExportBundle\Converter\SupportsAwareGenericConverter

--- a/config/pimcore/import/objects/converters_populators.yaml
+++ b/config/pimcore/import/objects/converters_populators.yaml
@@ -8,7 +8,6 @@ services:
     arguments:
       $converters: !tagged_iterator {tag: 'neusta_pimcore_import_export.objects.import.converter', default_priority_method: 'getPriority'}
     tags:
-      - { name: 'neusta.import_export.converter', type: 'Pimcore\Model\Concrete' }
       - { name: 'neusta.import_export.converter', type: 'Pimcore\Model\DataObject' }
 
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -119,6 +119,8 @@ services:
 
   Neusta\Pimcore\ImportExportBundle\Import\ParentRelationResolver: ~
 
+  Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository: ~
+
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\AssetRepository:
     public: true
     tags:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -109,7 +109,6 @@ services:
   Neusta\Pimcore\ImportExportBundle\Import\Strategy\ReplaceExistingElementStrategy:
     tags:
       - { name: 'neusta.import_export.merge_strategy', type: 'Pimcore\Model\Asset' }
-      - { name: 'neusta.import_export.merge_strategy', type: 'Pimcore\Model\Concrete' }
       - { name: 'neusta.import_export.merge_strategy', type: 'Pimcore\Model\DataObject' }
 
   ##############
@@ -139,8 +138,8 @@ services:
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\DataObjectRepository:
     public: true
     tags:
-      - { name: 'neusta.import_export.repository', type: 'Pimcore\Model\Concrete' }
       - { name: 'neusta.import_export.repository', type: 'Pimcore\Model\DataObject' }
+      - { name: 'neusta.import_export.repository', type: 'Pimcore\Model\Concrete' }
 
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\DocumentRepository:
     public: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -121,6 +121,16 @@ services:
 
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository: ~
 
+  Neusta\Pimcore\ImportExportBundle\Import\Registry\PendingTagsRegistry: ~
+
+  Neusta\Pimcore\ImportExportBundle\Populator\ImportTagsPopulator: ~
+
+  neusta_pimcore_import_export.import.tags.populator:
+    alias: Neusta\Pimcore\ImportExportBundle\Populator\ImportTagsPopulator
+    public: true
+
+  Neusta\Pimcore\ImportExportBundle\Import\EventSubscriber\ImportTagsEventSubscriber: ~
+
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\AssetRepository:
     public: true
     tags:

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,41 @@
+# Tags
+
+## Export
+
+Tags are exported when an element has assigned tags.
+
+An additional section is added:
+
+```yaml
+# (tag section for the element, see exporter output snapshots)
+```
+
+```mermaid
+sequenceDiagram
+  participant ExportConverter
+  participant AssignedTagsPopulator
+  participant TagRepository
+  participant PimcoreTagAPI
+  participant TagPopulator
+  ExportConverter->>AssignedTagsPopulator: populate assigned tags
+  AssignedTagsPopulator->>TagRepository: retrieve tags for element
+  TagRepository->>PimcoreTagAPI: query assigned tags
+  AssignedTagsPopulator->>TagPopulator: convert tag values
+  TagPopulator->>TagRepository: resolve tag idPath to names
+  TagRepository->>PimcoreTagAPI: retrieve tag names
+```
+
+## Import
+
+- The importer supports assigning tags to Assets, Documents and DataObjects.
+- Tag entries in the import YAML may contain either:
+  - an `id` (numeric) — in which case the tag must already exist; or
+  - a name-based path (e.g. `path` + `key`) — the importer will search for tags by their name path and create missing tags hierarchically.
+- Behaviour:
+  - If a tag is referenced by ID and does not exist, it cannot be assigned and the import will report the problem.
+  - If a tag is referenced by name (path/key), the importer will try to find it via `TagRepository::getByPath()`; if not found it will create the required tag nodes and then assign them.
+- Implementation notes:
+  - Tag resolution and creation use the bundle’s `TagRepository`.
+  - Assigned tags are registered during conversion (before the element has an ID) and are applied after the element is saved (via an import event subscriber), so the Pimcore element ID is available for assignment.
+  - Import events (`Created`/`Updated`/`Failed`/`Inconsistency`) are dispatched to allow logging and error handling.
+

--- a/src/Import/EventSubscriber/ImportTagsEventSubscriber.php
+++ b/src/Import/EventSubscriber/ImportTagsEventSubscriber.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Import\EventSubscriber;
+
+use Neusta\Pimcore\ImportExportBundle\Import\Event\ImportEvent;
+use Neusta\Pimcore\ImportExportBundle\Import\Event\ImportStatus;
+use Neusta\Pimcore\ImportExportBundle\Import\Registry\PendingTagsRegistry;
+use Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element\AbstractElement;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ImportTagsEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly PendingTagsRegistry $registry,
+        private readonly TagRepository $tagRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ImportEvent::class => 'onImportEvent',
+        ];
+    }
+
+    public function onImportEvent(ImportEvent $event): void
+    {
+        if (!\in_array($event->getStatus(), [ImportStatus::Created, ImportStatus::Updated], true)) {
+            return;
+        }
+
+        $newElement = $event->getNewElement();
+        if (null === $newElement) {
+            return;
+        }
+
+        $tags = $this->registry->consume($newElement->getFullPath());
+        if (empty($tags)) {
+            return;
+        }
+
+        // For UpdateExistingPageStrategy, $oldElement is saved in-place → use its ID.
+        // For ReplaceExistingElementStrategy, $newElement is saved with a new ID → use its ID.
+        $elementId = ($newElement->getId() ?: null) ?? $event->getOldElement()?->getId();
+        if (null === $elementId || 0 === $elementId) {
+            return;
+        }
+
+        $cType = $this->resolveCType($newElement);
+        if (null === $cType) {
+            return;
+        }
+
+        $this->tagRepository->setTagsForElement($cType, $elementId, $tags);
+    }
+
+    private function resolveCType(AbstractElement $element): ?string
+    {
+        return match (true) {
+            $element instanceof Asset => TagRepository::CTYPE_ASSET,
+            $element instanceof Document => TagRepository::CTYPE_DOCUMENT,
+            $element instanceof AbstractObject => TagRepository::CTYPE_DATAOBJECT,
+            default => null,
+        };
+    }
+}

--- a/src/Import/Importer.php
+++ b/src/Import/Importer.php
@@ -60,9 +60,9 @@ class Importer
             $result = null;
             $typeKey = key($element);
 
-            $repository = $this->repositoryLocator->get($typeKey);
-            $converter = $this->converterLocator->get($typeKey);
-            $mergeStrategy = $this->mergeStrategyLocator->get($typeKey);
+            $repository = $this->getServiceFromLocator($this->repositoryLocator, $typeKey);
+            $converter = $this->getServiceFromLocator($this->converterLocator, $typeKey);
+            $mergeStrategy = $this->getServiceFromLocator($this->mergeStrategyLocator, $typeKey);
 
             if (
                 $repository instanceof ImportRepositoryInterface
@@ -125,5 +125,20 @@ class Importer
     private function bothHaveSameId(AbstractElement $oldElement, AbstractElement $result): bool
     {
         return $oldElement->getId() === $result->getId();
+    }    private function getServiceFromLocator(ServiceLocator $locator, string $typeKey): object
+    {
+        if ($locator->has($typeKey)) {
+            return $locator->get($typeKey);
+        }
+
+        // Backwards-compatible fallback: many test kernels register DataObject
+        // converters/repositories under Pimcore\Model\Concrete only.
+        if ('Pimcore\\Model\\DataObject' === $typeKey && $locator->has('Pimcore\\Model\\Concrete')) {
+            return $locator->get('Pimcore\\Model\\Concrete');
+        }
+
+        // Let the original ServiceLocator produce the error (same behaviour as before)
+        return $locator->get($typeKey);
     }
 }
+

--- a/src/Import/Importer.php
+++ b/src/Import/Importer.php
@@ -125,7 +125,9 @@ class Importer
     private function bothHaveSameId(AbstractElement $oldElement, AbstractElement $result): bool
     {
         return $oldElement->getId() === $result->getId();
-    }    private function getServiceFromLocator(ServiceLocator $locator, string $typeKey): object
+    }
+
+    private function getServiceFromLocator(ServiceLocator $locator, string $typeKey): object
     {
         if ($locator->has($typeKey)) {
             return $locator->get($typeKey);

--- a/src/Import/Registry/PendingTagsRegistry.php
+++ b/src/Import/Registry/PendingTagsRegistry.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Import\Registry;
+
+use Pimcore\Model\Element\Tag;
+
+class PendingTagsRegistry
+{
+    /** @var array<string, Tag[]> */
+    private array $pending = [];
+
+    /**
+     * @param Tag[] $tags
+     */
+    public function register(string $fullPath, array $tags): void
+    {
+        $this->pending[$fullPath] = $tags;
+    }
+
+    /**
+     * Returns and removes the registered tags for the given full path.
+     *
+     * @return Tag[]
+     */
+    public function consume(string $fullPath): array
+    {
+        $tags = $this->pending[$fullPath] ?? [];
+        unset($this->pending[$fullPath]);
+
+        return $tags;
+    }
+}

--- a/src/Model/Element.php
+++ b/src/Model/Element.php
@@ -2,6 +2,8 @@
 
 namespace Neusta\Pimcore\ImportExportBundle\Model;
 
+use Neusta\Pimcore\ImportExportBundle\Model\Tag\Tag;
+
 class Element
 {
     public const ELEMENTS = 'elements';
@@ -11,4 +13,6 @@ class Element
     public string $type = 'element';
     public string $path = '';
     public string $key = '';
+    /** @var array<Tag> */
+    public array $tags; // important not to set default value here to avoid exporting empty arrays automatically
 }

--- a/src/Model/Tag/Tag.php
+++ b/src/Model/Tag/Tag.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Model\Tag;
+
+use Neusta\Pimcore\ImportExportBundle\Model\Element;
+
+class Tag extends Element
+{
+    public string $type = 'Pimcore\Model\Element\Tag';
+}

--- a/src/Model/Tag/Tag.php
+++ b/src/Model/Tag/Tag.php
@@ -6,5 +6,5 @@ use Neusta\Pimcore\ImportExportBundle\Model\Element;
 
 class Tag extends Element
 {
-    public string $type = 'Pimcore\Model\Element\Tag';
+    public string $type = \Pimcore\Model\Element\Tag::class;
 }

--- a/src/Populator/AssignedTagsPopulator.php
+++ b/src/Populator/AssignedTagsPopulator.php
@@ -34,12 +34,11 @@ class AssignedTagsPopulator implements Populator
             return;
         }
 
-        $cType = '';
-        match (true) {
-            $source instanceof Asset => $cType = TagRepository::CTYPE_ASSET,
-            $source instanceof Document => $cType = TagRepository::CTYPE_DOCUMENT,
-            $source instanceof AbstractObject => $cType = TagRepository::CTYPE_DATAOBJECT,
-            default => $cType = 'unknown',
+        $cType = match (true) {
+            $source instanceof Asset => TagRepository::CTYPE_ASSET,
+            $source instanceof Document => TagRepository::CTYPE_DOCUMENT,
+            $source instanceof AbstractObject => TagRepository::CTYPE_DATAOBJECT,
+            default => 'unknown',
         };
 
         if ('unknown' !== $cType) {

--- a/src/Populator/AssignedTagsPopulator.php
+++ b/src/Populator/AssignedTagsPopulator.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Populator;
+
+use Neusta\ConverterBundle\Converter;
+use Neusta\ConverterBundle\Converter\Context\GenericContext;
+use Neusta\ConverterBundle\Populator;
+use Neusta\Pimcore\ImportExportBundle\Model\Element;
+use Neusta\Pimcore\ImportExportBundle\Model\Tag\Tag as TagModel;
+use Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository;
+use Pimcore\Model\Asset;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\Document;
+use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\Tag;
+
+/**
+ * @implements Populator<AbstractElement, Element, GenericContext|null>
+ */
+class AssignedTagsPopulator implements Populator
+{
+    /**
+     * @param Converter<Tag, TagModel, GenericContext|null> $tagConverter
+     */
+    public function __construct(
+        private readonly TagRepository $tagRepository,
+        private readonly Converter $tagConverter,
+    ) {
+    }
+
+    public function populate(object $target, object $source, ?object $ctx = null): void
+    {
+        if (!$source->getId()) {
+            return;
+        }
+
+        $cType = '';
+        match (true) {
+            $source instanceof Asset => $cType = TagRepository::CTYPE_ASSET,
+            $source instanceof Document => $cType = TagRepository::CTYPE_DOCUMENT,
+            $source instanceof AbstractObject => $cType = TagRepository::CTYPE_DATAOBJECT,
+            default => $cType = 'unknown',
+        };
+
+        if ('unknown' !== $cType) {
+            $tags = $this->tagRepository->getTagsForElement($cType, $source->getId());
+            if (empty($tags)) {
+                return;
+            }
+            $target->tags = array_map(
+                fn (Tag $tag) => $this->tagConverter->convert($tag, $ctx),
+                $tags,
+            );
+        }
+    }
+}

--- a/src/Populator/ImportTagsPopulator.php
+++ b/src/Populator/ImportTagsPopulator.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Populator;
+
+use Neusta\ConverterBundle\Converter\Context\GenericContext;
+use Neusta\ConverterBundle\Populator;
+use Neusta\Pimcore\ImportExportBundle\Import\Registry\PendingTagsRegistry;
+use Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository;
+use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\Tag as PimcoreTag;
+
+/**
+ * Resolves tags from imported YAML data and registers them for post-save assignment.
+ *
+ * Tags with an `id` are looked up by ID (must exist).
+ * Tags without an `id` are found or created by their name path (`path` + `key`).
+ *
+ * @implements Populator<\ArrayObject<string, mixed>, AbstractElement, GenericContext|null>
+ */
+class ImportTagsPopulator implements Populator
+{
+    public function __construct(
+        private readonly TagRepository $tagRepository,
+        private readonly PendingTagsRegistry $registry,
+    ) {
+    }
+
+    /**
+     * @param \ArrayObject<string, mixed> $source
+     * @param AbstractElement             $target
+     * @param GenericContext|null         $ctx
+     */
+    public function populate(object $target, object $source, ?object $ctx = null): void
+    {
+        $tagsData = $source['tags'] ?? [];
+        if (empty($tagsData)) {
+            return;
+        }
+
+        $tags = [];
+        foreach ($tagsData as $tagData) {
+            $tag = $this->resolveTag($tagData);
+            if (null !== $tag) {
+                $tags[] = $tag;
+            }
+        }
+
+        if (!empty($tags)) {
+            $this->registry->register($target->getFullPath(), $tags);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $tagData
+     */
+    private function resolveTag(array $tagData): ?PimcoreTag
+    {
+        if (!empty($tagData['id']) && $tagData['id'] > 0) {
+            return $this->tagRepository->getById((int) $tagData['id']);
+        }
+
+        $path = $tagData['path'] ?? '/';
+        $key = $tagData['key'] ?? '';
+
+        if ('' === $key) {
+            return null;
+        }
+
+        $fullNamePath = rtrim($path, '/') . '/' . $key;
+
+        return $this->findOrCreateTagByNamePath($fullNamePath);
+    }
+
+    private function findOrCreateTagByNamePath(string $namePath): ?PimcoreTag
+    {
+        $segments = array_values(array_filter(explode('/', trim($namePath, '/'))));
+        if (empty($segments)) {
+            return null;
+        }
+
+        $parentId = 0;
+        $tag = null;
+        $builtPath = '';
+
+        foreach ($segments as $segment) {
+            $builtPath .= '/' . $segment;
+            $existing = $this->tagRepository->getByPath($builtPath);
+            if (null !== $existing) {
+                $tag = $existing;
+            } else {
+                $tag = new PimcoreTag();
+                $tag->setName($segment);
+                $tag->setParentId($parentId);
+                $tag->save();
+            }
+            $parentId = (int) $tag->getId();
+        }
+
+        return $tag;
+    }
+}

--- a/src/Populator/Tag/TagPopulator.php
+++ b/src/Populator/Tag/TagPopulator.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Populator\Tag;
+
+use Neusta\ConverterBundle\Converter\Context\GenericContext;
+use Neusta\ConverterBundle\Populator;
+use Neusta\Pimcore\ImportExportBundle\Model\Tag\Tag;
+use Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository;
+use Pimcore\Model\Element\Tag as PimcoreTag;
+
+/**
+ * @implements Populator<PimcoreTag, Tag ,GenericContext|null>
+ */
+class TagPopulator implements Populator
+{
+    public function __construct(
+        private readonly TagRepository $tagRepository,
+    ) {
+    }
+
+    public function populate(object $target, object $source, ?object $ctx = null): void
+    {
+        if ($ctx?->hasKey('includeIds') && true === $ctx->getValue('includeIds')) {
+            $target->id = $source->getId();
+            $target->parentId = $source->getParentId();
+            $target->path = $source->getIdPath();
+        } else {
+            $target->path = $this->resolveTagPathWithTagNames($source->getIdPath());
+        }
+    }
+
+    private function resolveTagPathWithTagNames(string $idPath): string
+    {
+        $ids = array_filter(explode('/', trim($idPath, '/')));
+        $keys = [];
+
+        foreach ($ids as $id) {
+            $tag = $this->tagRepository->getById((int) $id);
+            if (null === $tag) {
+                continue;
+            }
+
+            $keys[] = $tag->getName();
+        }
+
+        $concatenatedKeys = implode('/', $keys);
+        if (!empty($concatenatedKeys)) {
+            $concatenatedKeys .= '/';
+        }
+
+        return '/' . $concatenatedKeys;
+    }
+}

--- a/src/Toolbox/Repository/TagRepository.php
+++ b/src/Toolbox/Repository/TagRepository.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace Neusta\Pimcore\ImportExportBundle\Toolbox\Repository;
+
+use Pimcore\Model\Element\AbstractElement;
+use Pimcore\Model\Element\Tag;
+
+class TagRepository
+{
+    public const CTYPE_ASSET = 'asset';
+    public const CTYPE_DOCUMENT = 'document';
+    public const CTYPE_DATAOBJECT = 'object';
+
+    public function getById(int $id): ?Tag
+    {
+        return Tag::getById($id);
+    }
+
+    public function getByPath(string $path): ?Tag
+    {
+        return Tag::getByPath($path);
+    }
+
+    /**
+     * @return Tag[]
+     */
+    public function getTagsForAsset(int $assetId): array
+    {
+        return $this->getTagsForElement(self::CTYPE_ASSET, $assetId);
+    }
+
+    /**
+     * @return Tag[]
+     */
+    public function getTagsForDocument(int $documentId): array
+    {
+        return $this->getTagsForElement(self::CTYPE_DOCUMENT, $documentId);
+    }
+
+    /**
+     * @return Tag[]
+     */
+    public function getTagsForObject(int $objectId): array
+    {
+        return $this->getTagsForElement(self::CTYPE_DATAOBJECT, $objectId);
+    }
+
+    /**
+     * @return Tag[]
+     */
+    public function getTagsForElement(string $cType, int $cId): array
+    {
+        return Tag::getTagsForElement($cType, $cId);
+    }
+
+    public function addTagToAsset(int $cId, Tag $tag): void
+    {
+        Tag::addTagToElement(self::CTYPE_ASSET, $cId, $tag);
+    }
+
+    public function addTagToDocument(int $cId, Tag $tag): void
+    {
+        Tag::addTagToElement(self::CTYPE_DOCUMENT, $cId, $tag);
+    }
+
+    public function addTagToObject(int $cId, Tag $tag): void
+    {
+        Tag::addTagToElement(self::CTYPE_DATAOBJECT, $cId, $tag);
+    }
+
+    public function addTagToElement(string $cType, int $cId, Tag $tag): void
+    {
+        Tag::addTagToElement($cType, $cId, $tag);
+    }
+
+    public function removeTagFromElement(string $cType, int $cId, Tag $tag): void
+    {
+        Tag::removeTagFromElement($cType, $cId, $tag);
+    }
+
+    /**
+     * @param Tag[] $tags
+     */
+    public function setTagsForElement(string $cType, int $cId, array $tags): void
+    {
+        Tag::setTagsForElement($cType, $cId, $tags);
+    }
+
+    /**
+     * @param int[] $cIds
+     * @param int[] $tagIds
+     */
+    public function batchAssignTagsToElementIds(string $cType, array $cIds, array $tagIds, bool $replace = false): void
+    {
+        Tag::batchAssignTagsToElement($cType, $cIds, $tagIds, $replace);
+    }
+
+    /**
+     * @param iterable<AbstractElement> $objects
+     * @param iterable<int>             $tagIds
+     */
+    public function batchAssignTagsToElements(iterable $objects, iterable $tagIds, bool $replace = false): void
+    {
+        foreach ($this->filter($objects) as $object) {
+            $this->batchAssignTagsToElementIds($object->getType(), [$object->getId()], iterator_to_array($tagIds), $replace); // @phpstan-ignore-line
+        }
+    }
+
+    /**
+     * @param string[]       $subtypes
+     * @param class-string[] $classNames
+     *
+     * @return AbstractElement[]
+     */
+    public function getElementsForTag(
+        Tag $tag,
+        string $type,
+        array $subtypes = [],
+        array $classNames = [],
+        bool $considerChildTags = false,
+    ): array {
+        return Tag::getElementsForTag($tag, $type, $subtypes, $classNames, $considerChildTags);
+    }
+
+    /**
+     * @param iterable<AbstractElement> $objects
+     *
+     * @return iterable<AbstractElement>
+     */
+    private function filter(iterable $objects): iterable
+    {
+        foreach ($objects as $object) {
+            if ($object->getId() && \in_array($object->getType(), [self::CTYPE_ASSET, self::CTYPE_DOCUMENT, self::CTYPE_DATAOBJECT], true)) {
+                yield $object;
+            }
+        }
+    }
+}

--- a/tests/app/config/services.yaml
+++ b/tests/app/config/services.yaml
@@ -25,7 +25,7 @@ services:
         Pimcore\Model\Document\Page: '@neusta_pimcore_import_export.export_page'
         Pimcore\Model\Document\Snippet: '@neusta_pimcore_import_export.export_snippet'
         Pimcore\Model\Document\Folder: '@neusta_pimcore_import_export.export_folder'
-        Pimcore\Model\Concrete: '@neusta_pimcore_import_export.export_object'
+        Pimcore\Model\DataObject: '@neusta_pimcore_import_export.export_object'
       $serializer: '@Neusta\Pimcore\ImportExportBundle\Serializer\SerializerStrategy'
 
   ############
@@ -54,7 +54,7 @@ services:
   Neusta\Pimcore\ImportExportBundle\Import\Strategy\ReplaceElementStrategy:
     tags:
       - { name: 'neusta.import_export.merge_strategy', type: 'Pimcore\Model\Asset' }
-      - { name: 'neusta.import_export.merge_strategy', type: 'Pimcore\Model\Concrete' }
+      - { name: 'neusta.import_export.merge_strategy', type: 'Pimcore\Model\DataObject' }
 
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\AssetRepository:
     tags:
@@ -62,7 +62,7 @@ services:
 
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\DataObjectRepository:
     tags:
-      - { name: 'neusta.import_export.repository', type: 'Pimcore\Model\Concrete' }
+      - { name: 'neusta.import_export.repository', type: 'Pimcore\Model\DataObject' }
 
   Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\DocumentRepository:
     tags:

--- a/tests/app/config/services.yaml
+++ b/tests/app/config/services.yaml
@@ -10,6 +10,8 @@ services:
   Neusta\Pimcore\ImportExportBundle\Toolbox\:
     resource: '../../../src/Toolbox'
 
+  Neusta\Pimcore\ImportExportBundle\Toolbox\Repository\TagRepository: ~
+
   Neusta\Pimcore\ImportExportBundle\Tests\Integration\Documents\ImportExportYamlDriver: ~
 
   ############


### PR DESCRIPTION
All elements in Pimcore can have assigned Tags.
These tags can now be exported and re-imported with our bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export and import assigned tags for assets, documents, folders, and data objects.
  * Added support for exporting and importing Pimcore tags, including path-based resolution.
  * Added dedicated folder handling for data-object exports.
  * Added support for localized fields and path/key-based relations.
  * Object relations are exported as ID references to avoid circular references.

* **Documentation**
  * Documented localized-field and relation export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->